### PR TITLE
draft of auto-adjusting diurnal upstream queue settings.

### DIFF
--- a/blackice/Makefile
+++ b/blackice/Makefile
@@ -28,6 +28,7 @@ blackice: \
 	/etc/syslog.conf \
 	/etc/telegraf/telegraf.conf \
 	/etc/nut/upsmon.conf \
+	/home/grahams/bin/set-upstream-bandwidth.sh \
 	/var/log/unbound \
 	/var/unbound/etc/unbound.conf \
 	/var/unbound/etc/adblock.conf \
@@ -106,9 +107,11 @@ blackice: \
 	install -o root -g wheel -m 0644 \
 	  ntpd.conf /etc/ntpd.conf
 
-/etc/pf.conf : pf.conf
+/etc/pf.conf : pf.conf /home/grahams/bin/set-upstream-bandwidth.sh crontab-bandwidth
 	install -o root -g wheel -m 0600 \
 	  pf.conf /etc/pf.conf
+	/home/grahams/bin/set-upstream-bandwidth.sh
+	if ! [ -e /var/cron/tabs/grahams ]; then cat cronjob-bandwidth | doas crontab -u grahams - ; fi
 
 /etc/pf.sshbots: ../openbsd-skel/pf.sshbots
 	install -o root -g wheel -m 0600 \
@@ -153,6 +156,11 @@ blackice: \
 	  upsmon.conf /etc/nut/upsmon.conf
 	@if ! rcctl ls on | grep upsmon > /dev/null; then rcctl enable upsmon; fi
 	@if ! rcctl ls started | grep upsmon > /dev/null; then rcctl start upsmon; fi
+
+/home/grahams/bin/set-upstream-bandwidth.sh : set-upstream-bandwidth.sh
+	@if ! [ -d /home/grahams/bin ]; then mkdir /home/grahams/bin; fi
+	install -o grahams -g grahams -m 0750 \
+	  set-upstream-bandwidth.sh /home/grahams/bin/set-upstream-bandwidth.sh
 
 /var/log/unbound :
 	touch /var/log/unbound

--- a/blackice/cronjob-bandwidth
+++ b/blackice/cronjob-bandwidth
@@ -1,0 +1,1 @@
+@hourly 		/usr/bin/doas /home/grahams/bin/set-upstream-bandwidth.sh

--- a/blackice/pf.conf
+++ b/blackice/pf.conf
@@ -19,8 +19,12 @@ sietchtabr = "69.4.102.188"
 sietchtabr_lan = "192.168.223.0/24"
 
 # fair queueing, upstream
-upstream="12M"
-queue fq on $uplink flows 2048 bandwidth $upstream max $upstream qlimit 2048 default
+# This rule is twiddled via set-upstream-bandwidth.sh, usually via
+# cron(8). The variable names are magic, and the queue rule itself must
+# always remain in a single line.
+upstream_offpeak="12M"
+upstream_peak="8M"
+queue fq on $uplink flows 2048 bandwidth $upstream_offpeak max $upstream_offpeak qlimit 2048 default
 
 # fair queueing, downstream
 downstream="650M"

--- a/blackice/set-upstream-bandwidth.sh
+++ b/blackice/set-upstream-bandwidth.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # Usage: '-t' means to test, outputting to /tmp/pf.conf instead of
 # /etc/pf.conf.
@@ -12,8 +13,10 @@ HOUR_NOW=$(date|cut -d ' ' -f 4|cut -d ':' -f 1)
 
 if [ "$1" = "-t" ]; then
   OUTPUT="/tmp/pf.conf"
+  RELOAD="no"
 else
   OUTPUT="/etc/pf.conf"
+  RELOAD="yes"
 fi
 
 # The ed operations below find lines which start with:
@@ -38,4 +41,8 @@ else
 w $OUTPUT
 q
 EOF
+fi
+
+if [ $RELOAD = "yes" ]; then
+  /sbin/pfctl -nf /etc/pf.conf && /sbin/pfctl -f /etc/pf.conf
 fi

--- a/blackice/set-upstream-bandwidth.sh
+++ b/blackice/set-upstream-bandwidth.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+# Usage: '-t' means to test, outputting to /tmp/pf.conf instead of
+# /etc/pf.conf.
+
+# These hours are firewall's local timezone
+PEAK_START_HOUR="16"
+PEAK_END_HOUR="23"
+
+# Cut out only the hour portion of the time
+HOUR_NOW=$(date|cut -d ' ' -f 4|cut -d ':' -f 1)
+
+if [ $1 == "-t" ]; then
+  OUTPUT="/tmp/pf.conf"
+else
+  OUTPUT="/etc/pf.conf"
+fi
+
+# The ed operations below find lines which start with:
+#   "queue fq on $uplink"
+# They then replace any word on that line beginning with:
+#   "$upstream_"
+# with either $upstream_peak or $upstream_offpeak, depending on the hour
+# of the day.
+if [ $HOUR_NOW -ge $PEAK_START_HOUR ]; then
+  if [ $HOUR_NOW -le $PEAK_END_HOUR ]; then
+    # The current hour is inside peak times
+    ed -s /etc/pf.conf << EOF
+/^queue fq on [$]uplink/s/[$]upstream_[^ ]*/\$upstream_peak/g
+w $OUTPUT
+q
+EOF
+  fi
+else
+  # the current hour is outside peak times
+  ed -s /etc/pf.conf << EOF
+/^queue fq on [$]uplink/s/[$]upstream_[^ ]*/\$upstream_offpeak/g
+w $OUTPUT
+q
+EOF
+fi

--- a/blackice/set-upstream-bandwidth.sh
+++ b/blackice/set-upstream-bandwidth.sh
@@ -10,7 +10,7 @@ PEAK_END_HOUR="23"
 # Cut out only the hour portion of the time
 HOUR_NOW=$(date|cut -d ' ' -f 4|cut -d ':' -f 1)
 
-if [ $1 == "-t" ]; then
+if [ "$1" = "-t" ]; then
   OUTPUT="/tmp/pf.conf"
 else
   OUTPUT="/etc/pf.conf"


### PR DESCRIPTION
Here's one way this could work. My assumptions about what makes a good solution:

1. It's still possible and normal to edit pf.conf both in this repository and in /etc/ on blackice (no templates).
2. Bandwidth settings for peak and offpeak should live in pf.conf (no multi-file inputs to produce pf.conf).
3. It should support both automation via cron or whatever, but also manually running a script to get this set right for "now."
4. Everything should be idempotent-feeling, it's all a one-way-and-overwrites-are-fine process.

The script uses ed(1) to find the uplink queue statement in /etc/pf.conf and replace the bandwidth variable names with the appropriate-for-now ones (either _peak or _offpeak).

I adjusted the Makefile so it'll do the right thing on install, so make /etc/pf.conf will work. I copied the crontab idiom used for the existing adblock cron job.

I made the script live in ~grahams/bin, but really it could go anywhere. Cronjob runs as grahams and depends on doas.