### PR TITLE
blueant: nodeless vpn changes

### DIFF
--- a/blueant/pf.conf
+++ b/blueant/pf.conf
@@ -41,7 +41,7 @@ downstream="9500M"
 #queue fq on $lan flows 2048 bandwidth $downstream max $downstream qlimit 2048 default
 
 # fair queueing, nodeless vpn
-queue fq-nodeless on sec0 flows 2048 bandwidth 300M, max 300M default qlimit 2048
+queue fq-nodeless on sec0 flows 2048 bandwidth 400M max 400M default qlimit 2048
 
 set block-policy drop
 set loginterface $wan
@@ -99,8 +99,8 @@ pass in  log quick on egress inet6 \
     (max-src-conn 3, max-src-conn-rate 10/5, overload <scannerbots> flush global)
 
 match in all scrub (no-df random-id max-mss 1460)
-# "clamp" TCP mss on vpn link to avoid PMTU
-match on sec0 all scrub (max-mss 1240)
+# "clamp" TCP mss on any vpn sec(4) interfaces to avoid PMTU
+match on sec all scrub (max-mss 1240)
 match out on $wan inet from !($wan:network) to any nat-to ($wan:0)
 
 antispoof quick for { $wan $lan }


### PR DESCRIPTION
properly clamp mss on any sec interfaces, optimize sec0 fair queueing